### PR TITLE
chore(testing): add integration test for init command

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,10 +7,10 @@ jobs:
       - checkout
       - run:
           name: install
-          command: npm install
+          command: yarn install
       - run:
           name: test
-          command: npm test
+          command: yarn test
       - run:
           name: release
-          command: npm run semantic-release || true
+          command: yarn semantic-release || true

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # eb-scripts
+
 [![All Contributors](https://img.shields.io/badge/all_contributors-4-orange.svg?style=flat-square)](#contributors)
 
 A CLI and scripts used at Echobind
@@ -9,15 +10,17 @@ A CLI and scripts used at Echobind
 [![License](https://img.shields.io/npm/l/eb-scripts.svg)](https://github.com/echobind/eb-scripts/blob/master/package.json)
 
 <!-- toc -->
-* [eb-scripts](#eb-scripts)
-* [Usage](#usage)
-* [Commands](#commands)
-* [Contributing](#contributing)
-<!-- tocstop -->
+
+- [eb-scripts](#eb-scripts)
+- [Usage](#usage)
+- [Commands](#commands)
+- [Contributing](#contributing)
+  <!-- tocstop -->
 
 # Usage
 
 <!-- usage -->
+
 ```sh-session
 $ npm install -g eb-scripts
 $ eb-scripts COMMAND
@@ -29,14 +32,16 @@ USAGE
   $ eb-scripts COMMAND
 ...
 ```
+
 <!-- usagestop -->
 
 # Commands
 
 <!-- commands -->
-* [`eb-scripts generate TEMPLATE NAME [COMPONENT NAME]`](#eb-scripts-generate-template-name-component-name)
-* [`eb-scripts help [COMMAND]`](#eb-scripts-help-command)
-* [`eb-scripts init PROJECT`](#eb-scripts-init-project)
+
+- [`eb-scripts generate TEMPLATE NAME [COMPONENT NAME]`](#eb-scripts-generate-template-name-component-name)
+- [`eb-scripts help [COMMAND]`](#eb-scripts-help-command)
+- [`eb-scripts init PROJECT`](#eb-scripts-init-project)
 
 ## `eb-scripts generate TEMPLATE NAME [COMPONENT NAME]`
 
@@ -100,6 +105,7 @@ EXAMPLE
 ```
 
 _See code: [src/commands/init.ts](https://github.com/echobind/eb-scripts/blob/v0.0.0-development/src/commands/init.ts)_
+
 <!-- commandsstop -->
 
 # Contributing

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
   "scripts": {
     "postpack": "rm -f oclif.manifest.json",
     "prepack": "rm -rf lib && tsc -b && oclif-dev manifest && oclif-dev readme",
-    "test": "jest",
+    "test": "jest --runInBand",
     "version": "oclif-dev readme && git add README.md",
     "gen": "hygen",
     "semantic-release": "semantic-release"

--- a/src/__tests__/__snapshots__/generate.test.ts.snap
+++ b/src/__tests__/__snapshots__/generate.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`The \`generate\` command throws an error when you pass an invalid flag 1`] = `
 "Command failed: ./bin/run generate -t fake-component -n FakeComponent
- [31m›[39m   Error: Expected --template=fake-component to be one of: react-component
- [31m›[39m   See more help with --help
+ ›   Error: Expected --template=fake-component to be one of: react-component
+ ›   See more help with --help
 "
 `;

--- a/src/__tests__/__snapshots__/init.test.ts.snap
+++ b/src/__tests__/__snapshots__/init.test.ts.snap
@@ -1,0 +1,8 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`The \`init\` command throws an error when you pass an invalid flag 1`] = `
+"Command failed: ./bin/run init -p rust
+ [31m›[39m   Error: Expected --project=rust to be one of: react
+ [31m›[39m   See more help with --help
+"
+`;

--- a/src/__tests__/__snapshots__/init.test.ts.snap
+++ b/src/__tests__/__snapshots__/init.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`The \`init\` command throws an error when you pass an invalid flag 1`] = `
 "Command failed: ./bin/run init -p rust
- [31m›[39m   Error: Expected --project=rust to be one of: react
- [31m›[39m   See more help with --help
+ ›   Error: Expected --project=rust to be one of: react
+ ›   See more help with --help
 "
 `;

--- a/src/__tests__/getTemplateLocation.test.ts
+++ b/src/__tests__/getTemplateLocation.test.ts
@@ -1,10 +1,17 @@
-import { DEFAULT_TEMPLATE_PATH, getTemplateLocation } from "../utils";
+import {
+  DEFAULT_TEMPLATE_PATH,
+  getTemplateLocation
+} from "../utils/getTemplateLocation";
 
 afterEach(() => {
   jest.resetModules();
 });
 
-describe("getTemplateLocation", () => {
+afterAll(() => {
+  jest.restoreAllMocks();
+});
+
+describe("my thing", () => {
   it("uses default template if dev does not have custom ones", () => {
     jest.dontMock("fs");
 
@@ -13,11 +20,11 @@ describe("getTemplateLocation", () => {
     expect(templateLocation).toEqual(DEFAULT_TEMPLATE_PATH);
   });
 
-  it.skip("uses developer custom templates if defined", () => {
+  it("uses developer custom templates if defined", () => {
     jest.mock("fs");
-    jest.mock("process", () => ({
-      cwd: () => "/custom/path/to"
-    }));
+    jest.spyOn(process, "cwd").mockImplementation(() => "/custom/path/to");
+
+    const { getTemplateLocation } = require("../utils/getTemplateLocation");
 
     const templateLocation = getTemplateLocation();
 

--- a/src/__tests__/getTemplateLocation.test.ts
+++ b/src/__tests__/getTemplateLocation.test.ts
@@ -3,15 +3,15 @@ import {
   getTemplateLocation
 } from "../utils/getTemplateLocation";
 
-afterEach(() => {
-  jest.resetModules();
-});
-
-afterAll(() => {
-  jest.restoreAllMocks();
-});
-
 describe("my thing", () => {
+  afterEach(() => {
+    jest.resetModules();
+  });
+
+  afterAll(() => {
+    jest.restoreAllMocks();
+  });
+
   it("uses default template if dev does not have custom ones", () => {
     jest.dontMock("fs");
 

--- a/src/__tests__/getTemplateLocation.test.ts
+++ b/src/__tests__/getTemplateLocation.test.ts
@@ -15,7 +15,9 @@ describe("getTemplateLocation", () => {
 
   it.skip("uses developer custom templates if defined", () => {
     jest.mock("fs");
-    jest.spyOn(process, "cwd").mockImplementation(() => "/custom/path/to");
+    jest.mock("process", () => ({
+      cwd: () => "/custom/path/to"
+    }));
 
     const templateLocation = getTemplateLocation();
 

--- a/src/__tests__/getTemplateLocation.test.ts
+++ b/src/__tests__/getTemplateLocation.test.ts
@@ -3,7 +3,7 @@ import {
   getTemplateLocation
 } from "../utils/getTemplateLocation";
 
-describe("my thing", () => {
+describe("getTemplateLocation", () => {
   afterEach(() => {
     jest.resetModules();
   });

--- a/src/__tests__/getTemplateLocation.test.ts
+++ b/src/__tests__/getTemplateLocation.test.ts
@@ -24,6 +24,10 @@ describe("getTemplateLocation", () => {
     jest.mock("fs");
     jest.spyOn(process, "cwd").mockImplementation(() => "/custom/path/to");
 
+    // We import this function here because of the way Jest mocks process.cwd
+    // If we delete this import and use the "global" import at the top of the file
+    // Jest doesn't mock process.cwd() correctly
+    // See discussion: https://github.com/echobind/eb-scripts/pull/29#discussion_r342288096
     const { getTemplateLocation } = require("../utils/getTemplateLocation");
 
     const templateLocation = getTemplateLocation();

--- a/src/__tests__/init.test.ts
+++ b/src/__tests__/init.test.ts
@@ -100,42 +100,4 @@ describe("The `init` command", () => {
 
     expect(initCommand).toThrowErrorMatchingSnapshot();
   });
-
-  it.skip("uses the users template if they have one", async () => {
-    const pathToNewTemplate = `${root}/_templates/react-component/new`;
-    const newComponentName = "Test";
-    // Make a react-component template
-    await fse.ensureDir(pathToNewTemplate);
-    // Add template to _templates/react-component/new
-    await fse.copyFileSync(
-      `${root}/src/__tests__/helpers/componentTestTemplate.ejs.t`,
-      `${pathToNewTemplate}/component.ejs.t`
-    );
-
-    const newTemplateFolderExists = await fse.pathExists(pathToNewTemplate);
-    const newTemplateFileExists = fse.existsSync(
-      `${pathToNewTemplate}/component.ejs.t`
-    );
-
-    // Check that it made our template and new file
-    expect(newTemplateFolderExists).toBe(true);
-    expect(newTemplateFileExists).toBe(true);
-
-    execSync(`./bin/run generate -t react-component -n ${newComponentName}`, {
-      cwd: root
-    });
-
-    // Using the template we created, we expect to see a new component
-    const newGeneratedComponentExists = fse.existsSync(
-      `${root}/${newComponentName}.jsx`
-    );
-
-    // And no folder for the component
-    const newGeneratedComponentFolderExists = await fse.pathExists(
-      `${root}/${newComponentName}`
-    );
-
-    expect(newGeneratedComponentExists).toBe(true);
-    expect(newGeneratedComponentFolderExists).toBe(false);
-  });
 });

--- a/src/__tests__/init.test.ts
+++ b/src/__tests__/init.test.ts
@@ -67,10 +67,12 @@ describe("The `init` command", () => {
 
     // Check for eb-scripts in the devDependencies
     const hasEbScripts = Object.keys(devDependencies).includes("eb-scripts");
+    // The default project for the init project is react
+    // which includes a g:component script so we check for that
+    const hasGComponentScript = Object.keys(scripts).includes("g:component");
 
     expect(hasEbScripts).toBe(true);
-
-    // Check for the g:component script...
+    expect(hasGComponentScript).toBe(true);
   });
 
   it.skip("works with a flag of a valid template flag", async () => {

--- a/src/__tests__/init.test.ts
+++ b/src/__tests__/init.test.ts
@@ -75,47 +75,30 @@ describe("The `init` command", () => {
     expect(hasGComponentScript).toBe(true);
   });
 
-  it.skip("works with a flag of a valid template flag", async () => {
-    const componentName = "TestComponent";
-    const componentFolderPath = `${root}/${componentName}`;
-
-    execSync(`./bin/run init -t react-component -n ${componentName}`, {
+  it("works with a flag of a valid template flag (react)", async () => {
+    execSync(`./bin/run init -p react`, {
       cwd: root
     });
 
-    const newComponentFolderExists = await fse.pathExists(componentFolderPath);
-    const componentIndexExists = fse.existsSync(
-      `${componentFolderPath}/index.js`
-    );
+    const packageJson = require(`${root}/package.json`);
+    const scripts = packageJson.scripts;
 
-    expect(newComponentFolderExists).toBe(true);
-    expect(componentIndexExists).toBe(true);
+    const devDependencies = packageJson.devDependencies;
+
+    const hasEbScripts = Object.keys(devDependencies).includes("eb-scripts");
+    const hasGComponentScript = Object.keys(scripts).includes("g:component");
+
+    expect(hasEbScripts).toBe(true);
+    expect(hasGComponentScript).toBe(true);
   });
 
-  it.skip("uses the default templates if none in the users directory", async () => {
-    const componentName = "DefaultTemplateComponent";
-    const componentFolderPath = `${root}/${componentName}`;
-
-    execSync(`./bin/run generate -t react-component -n ${componentName}`, {
-      cwd: root
-    });
-
-    const newComponentFolderExists = await fse.pathExists(componentFolderPath);
-    const componentIndexExists = fse.existsSync(
-      `${componentFolderPath}/index.js`
-    );
-
-    expect(newComponentFolderExists).toBe(true);
-    expect(componentIndexExists).toBe(true);
-  });
-
-  it.skip("throws an error when you pass an invalid flag", () => {
-    const generateCommand = () =>
-      execSync(`./bin/run generate -t fake-component -n FakeComponent`, {
+  it("throws an error when you pass an invalid flag", () => {
+    const initCommand = () =>
+      execSync(`./bin/run init -p rust`, {
         cwd: root
       });
 
-    expect(generateCommand).toThrowErrorMatchingSnapshot();
+    expect(initCommand).toThrowErrorMatchingSnapshot();
   });
 
   it.skip("uses the users template if they have one", async () => {

--- a/src/__tests__/init.test.ts
+++ b/src/__tests__/init.test.ts
@@ -1,0 +1,135 @@
+import * as path from "path";
+import * as fse from "fs-extra";
+import { execSync } from "child_process";
+import { DEFAULT_COMPONENT_NAME } from "../commands/generate";
+
+let root = process.cwd();
+let tempRoot = path.join(`${root}`, "/temp");
+
+describe("The `init` command", () => {
+  beforeAll(async () => {
+    try {
+      // create our temporary directory
+      await fse.ensureDir(tempRoot);
+      // create a package.json so we have something to work with
+      execSync("yarn init -y", { cwd: tempRoot });
+    } catch (error) {
+      console.error(error);
+    }
+  });
+
+  afterAll(async () => {
+    try {
+      // delete our temporary directories
+      await fse.remove(tempRoot);
+    } catch (err) {
+      console.error(err);
+    }
+  });
+
+  it("expects to find a temporary directory in temp, which contains a package.json", async () => {
+    const tempDirectoryExists = await fse.pathExists(tempRoot);
+    const tempPackageJsonExists = fse.existsSync(`${tempRoot}/package.json`);
+
+    expect(tempDirectoryExists).toBe(true);
+    expect(tempPackageJsonExists).toBe(true);
+  });
+
+  it("works without flags", async () => {
+    // Run the command
+    execSync(`./bin/run init`, {
+      cwd: tempRoot
+    });
+
+    const packageJson = require(`${tempRoot}/package.json`);
+    const scripts = packageJson.scripts;
+
+    const devDependencies = packageJson.devDependencies;
+
+    // Check for eb-scripts in the devDependencies
+    const hasEbScripts = Object.keys(devDependencies).includes("eb-scripts");
+
+    expect(hasEbScripts).toBe(true);
+  });
+
+  it.skip("works with a flag of a valid template flag", async () => {
+    const componentName = "TestComponent";
+    const componentFolderPath = `${tempRoot}/${componentName}`;
+
+    execSync(`./bin/run init -t react-component -n ${componentName}`, {
+      cwd: root
+    });
+
+    const newComponentFolderExists = await fse.pathExists(componentFolderPath);
+    const componentIndexExists = fse.existsSync(
+      `${componentFolderPath}/index.js`
+    );
+
+    expect(newComponentFolderExists).toBe(true);
+    expect(componentIndexExists).toBe(true);
+  });
+
+  it.skip("uses the default templates if none in the users directory", async () => {
+    const componentName = "DefaultTemplateComponent";
+    const componentFolderPath = `${tempRoot}/${componentName}`;
+
+    execSync(`./bin/run generate -t react-component -n ${componentName}`, {
+      cwd: root
+    });
+
+    const newComponentFolderExists = await fse.pathExists(componentFolderPath);
+    const componentIndexExists = fse.existsSync(
+      `${componentFolderPath}/index.js`
+    );
+
+    expect(newComponentFolderExists).toBe(true);
+    expect(componentIndexExists).toBe(true);
+  });
+
+  it.skip("throws an error when you pass an invalid flag", () => {
+    const generateCommand = () =>
+      execSync(`./bin/run generate -t fake-component -n FakeComponent`, {
+        cwd: root
+      });
+
+    expect(generateCommand).toThrowErrorMatchingSnapshot();
+  });
+
+  it.skip("uses the users template if they have one", async () => {
+    const pathToNewTemplate = `${root}/_templates/react-component/new`;
+    const newComponentName = "Test";
+    // Make a react-component template
+    await fse.ensureDir(pathToNewTemplate);
+    // Add template to _templates/react-component/new
+    await fse.copyFileSync(
+      `${root}/src/__tests__/helpers/componentTestTemplate.ejs.t`,
+      `${pathToNewTemplate}/component.ejs.t`
+    );
+
+    const newTemplateFolderExists = await fse.pathExists(pathToNewTemplate);
+    const newTemplateFileExists = fse.existsSync(
+      `${pathToNewTemplate}/component.ejs.t`
+    );
+
+    // Check that it made our template and new file
+    expect(newTemplateFolderExists).toBe(true);
+    expect(newTemplateFileExists).toBe(true);
+
+    execSync(`./bin/run generate -t react-component -n ${newComponentName}`, {
+      cwd: root
+    });
+
+    // Using the template we created, we expect to see a new component
+    const newGeneratedComponentExists = fse.existsSync(
+      `${tempRoot}/${newComponentName}.jsx`
+    );
+
+    // And no folder for the component
+    const newGeneratedComponentFolderExists = await fse.pathExists(
+      `${tempRoot}/${newComponentName}`
+    );
+
+    expect(newGeneratedComponentExists).toBe(true);
+    expect(newGeneratedComponentFolderExists).toBe(false);
+  });
+});

--- a/src/__tests__/init.test.ts
+++ b/src/__tests__/init.test.ts
@@ -44,7 +44,7 @@ describe("The `init` command", () => {
     }
   });
 
-  it("expects to find a backup.json and package.json", async () => {
+  it("expects to find a backup.json, backupYarn.lock and package.json", async () => {
     const backupJsonExists = fse.existsSync(`${root}/${backupJson}`);
     const backupYarnLockExists = fse.existsSync(`${root}/${backupYarnLock}`);
     const packageJsonExists = fse.existsSync(`${root}/package.json`);

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -34,6 +34,8 @@ const scriptsByProject: ScriptByProject = {
     "g:component": "eb-scripts generate -t react-component -n"
   }
 };
+
+const validProjectTypes: ProjectType[] = ["react"];
 export default class Init extends Command {
   static description =
     "initializes project by installing `eb-scripts` and adding scripts to `package.json`";
@@ -45,7 +47,8 @@ export default class Init extends Command {
     // flag with a value (-p, --project=VALUE)
     project: flags.string({
       char: "p",
-      description: "language/framework of project"
+      description: "language/framework of project",
+      options: validProjectTypes
     })
   };
 


### PR DESCRIPTION
This PR adds some integration tests for the `init` command

## Changes
Adds tests for the following:
- the `init` command works without a flag
- the `init` command works with a flag of a valid project
- the `init` command displays an error when you pass an invalid flag
- the `init` command installs `eb-scripts` and adds a script to the `package.json`

## Screenshots

![image](https://user-images.githubusercontent.com/3806031/68149012-5a31c100-fefa-11e9-9144-5678b81f02bf.png)


## Checklist

- [x] tested locally
- [ ] installed new dependencies
- [ ] updated the docs
- [x] added a test

Fixes #19 
