### PR TITLE
chore(release): add commit-analyzer and release-notes-generator

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ jobs:
       - checkout
       - run:
           name: install
-          command: npm ci
+          command: npm install
       - run:
           name: test
           command: npm test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,4 +13,4 @@ jobs:
           command: npm test
       - run:
           name: release
-          command: npm run semantic-release || true
+          command: npm run semantic-release

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,10 +7,10 @@ jobs:
       - checkout
       - run:
           name: install
-          command: yarn install
+          command: npm ci
       - run:
           name: test
-          command: yarn test
+          command: npm test
       - run:
           name: release
-          command: yarn semantic-release
+          command: npm run semantic-release

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ jobs:
       - checkout
       - run:
           name: install
-          command: npm install
+          command: npm ci
       - run:
           name: test
           command: npm test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,10 +7,10 @@ jobs:
       - checkout
       - run:
           name: install
-          command: npm ci
+          command: yarn install
       - run:
           name: test
-          command: npm test
+          command: yarn test
       - run:
           name: release
-          command: npm run semantic-release
+          command: yarn semantic-release

--- a/package.json
+++ b/package.json
@@ -16,9 +16,11 @@
   },
   "devDependencies": {
     "@oclif/dev-cli": "^1",
+    "@semantic-release/commit-analyzer": "^6.3.2",
     "@semantic-release/git": "^7.0.17",
     "@semantic-release/npm": "^5.3.2",
     "@types/fs-extra": "^8.0.1",
+    "@semantic-release/release-notes-generator": "^7.3.2",
     "@types/jest": "^24.0.21",
     "@types/node": "^12.12.3",
     "fs-extra": "^8.1.0",
@@ -78,6 +80,38 @@
             "package.json"
           ],
           "message": "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"
+        }
+      ],
+      [
+        "semantic-release/commit-analyzer",
+        {
+          "preset": "angular",
+          "parserOpts": {
+            "noteKeywords": [
+              "BREAKING CHANGE",
+              "BREAKING CHANGES",
+              "BREAKING"
+            ]
+          }
+        }
+      ],
+      [
+        "semantic-release/release-notes-generator",
+        {
+          "preset": "angular",
+          "parserOpts": {
+            "noteKeywords": [
+              "BREAKING CHANGE",
+              "BREAKING CHANGES",
+              "BREAKING"
+            ]
+          },
+          "writerOpts": {
+            "commitsSort": [
+              "subject",
+              "scope"
+            ]
+          }
         }
       ]
     ]

--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
         }
       ],
       [
-        "semantic-release/commit-analyzer",
+        "@semantic-release/commit-analyzer",
         {
           "preset": "angular",
           "parserOpts": {
@@ -96,7 +96,7 @@
         }
       ],
       [
-        "semantic-release/release-notes-generator",
+        "@semantic-release/release-notes-generator",
         {
           "preset": "angular",
           "parserOpts": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -465,6 +465,18 @@
     import-from "^3.0.0"
     lodash "^4.17.4"
 
+"@semantic-release/commit-analyzer@^6.3.2":
+  version "6.3.2"
+  resolved "https://registry.yarnpkg.com/@semantic-release/commit-analyzer/-/commit-analyzer-6.3.2.tgz#f30d621ede11d4060fe6b9d689559ff6ff7df7de"
+  integrity sha512-TezpOODuMcdDuGcGsI2QRqkH3sT7ffhsxid9J8OyspXDe8E4tshekJESJ6Pq8jTrggluKd3tCK26Vsyu6SkeSg==
+  dependencies:
+    conventional-changelog-angular "^5.0.0"
+    conventional-commits-filter "^2.0.0"
+    conventional-commits-parser "^3.0.0"
+    debug "^4.0.0"
+    import-from "^3.0.0"
+    lodash "^4.17.4"
+
 "@semantic-release/error@^2.1.0", "@semantic-release/error@^2.2.0":
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/@semantic-release/error/-/error-2.2.0.tgz#ee9d5a09c9969eade1ec864776aeda5c5cddbbf0"
@@ -526,7 +538,7 @@
     registry-auth-token "^4.0.0"
     tempy "^0.3.0"
 
-"@semantic-release/release-notes-generator@^7.1.2":
+"@semantic-release/release-notes-generator@^7.1.2", "@semantic-release/release-notes-generator@^7.3.2":
   version "7.3.2"
   resolved "https://registry.yarnpkg.com/@semantic-release/release-notes-generator/-/release-notes-generator-7.3.2.tgz#a858b35c9c62f780d285aeaca8ef9891a62c2f9c"
   integrity sha512-vYGydZPoQqL4aJOsaqXTZIekRb3aa/OlxlEVUvyrWWlNGqmQ1T7NUOos9eoN5DBCEuk6PwDrxPbhzgswxcvprQ==


### PR DESCRIPTION
This PR adds the plugins `commit-analyzer`  and `release-notes-generator` suggested by @cball. 

The plugin configuration settings used are from the usage section on the `semantic-release/release-notes-generator` README, which you can view [here](https://github.com/semantic-release/release-notes-generator#usage).

The gist:
- analyze the commits. If any commits contain "BREAKING CHANGE" or the variation listed in the screenshot, it will be considering a breaking change and bump the version automatically (from what I can tell). 

This may be a trial as we go scenario. 

## Changes
- adds `commit-analyzer`
- adds `release-notes-generator

## Screenshots

![image](https://user-images.githubusercontent.com/3806031/68221388-96baf680-ffa6-11e9-9d98-6567a8599dfe.png)


## Checklist

- [ ] tested locally
- [x] installed new dependencies
  - `@semantic-release/commit-analyzer`
  - `@semantic-release/release-notes-generator`
- [ ] updated the docs
- [ ] added a test

Fixes #17 
Fixes #27 
