### PR TITLE
Jsjoeio/issue 27 ensure failures surfaced

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,4 +13,4 @@ jobs:
           command: npm test
       - run:
           name: release
-          command: npm run semantic-release || true
+          command: npm run semantic-release


### PR DESCRIPTION
This PR fixes the issue @alvincrespo noted in #27 - we were using the default suggested by `semantic-release`, which ran the "release" command even if the release failed. This should prevent that. 

## Changes
- remove `|| true` in `config.yml` at command "release"

## Screenshots

N/A

## Checklist

- [ ] tested locally
- [ ] installed new dependencies
- [ ] updated the docs
- [ ] added a test

Fixes #27 
