### PR TITLE
fix: react-native-typescript template casing

### DIFF
--- a/_templates/react-native-typescript-component/new/component.ejs
+++ b/_templates/react-native-typescript-component/new/component.ejs
@@ -1,7 +1,8 @@
+
 ---
-to: <%= root %>/<%= path %>/<%= h.inflection.transform(name, ['undasherize', 'classify']) %>/<%= h.inflection.transform(name, ['undasherize', 'classify']) %>.tsx
+to: <%= root %>/<%= path %>/<%= h.changeCase.pascal(name) %>/<%= h.changeCase.pascal(name) %>.tsx
 ---
-<% const formattedName = h.inflection.transform(name, ['undasherize', 'classify']) -%>
+<% const formattedName = h.changeCase.pascal(name) -%>
 import React, { FC } from 'react';
 
 import { Container } from '../Container';

--- a/_templates/react-native-typescript-component/new/component.ejs
+++ b/_templates/react-native-typescript-component/new/component.ejs
@@ -1,4 +1,3 @@
-
 ---
 to: <%= root %>/<%= path %>/<%= h.changeCase.pascal(name) %>/<%= h.changeCase.pascal(name) %>.tsx
 ---

--- a/_templates/react-native-typescript-component/new/export.ejs
+++ b/_templates/react-native-typescript-component/new/export.ejs
@@ -1,4 +1,4 @@
 ---
-to: <%= root %>/<%= path %>/<%= h.inflection.transform(name, ['undasherize', 'classify']) %>/index.ts
+to: <%= root %>/<%= path %>/<%= h.changeCase.pascal(name) %>/index.ts
 ---
-export * from './<%= h.inflection.transform(name, ['undasherize', 'classify'])%>';
+export * from './<%= h.changeCase.pascal(name) %>';

--- a/_templates/react-native-typescript-component/new/inject_story.ejs
+++ b/_templates/react-native-typescript-component/new/inject_story.ejs
@@ -4,5 +4,5 @@ to: <%= root %>/storybook/stories/index.ts
 append: true
 ---
 
-<% formattedName = h.inflection.transform(name, ['undasherize', 'classify']) -%>
+<% formattedName = h.changeCase.pascal(name) -%>
 import '../../<%= path %>/<%= formattedName %>/<%= formattedName %>.stories';

--- a/_templates/react-native-typescript-component/new/stories.ejs
+++ b/_templates/react-native-typescript-component/new/stories.ejs
@@ -1,7 +1,7 @@
 ---
-to: <%= root %>/<%= path %>/<%= h.inflection.transform(name, ['undasherize', 'classify']) %>/<%= h.inflection.transform(name, ['undasherize', 'classify']) %>.stories.tsx
+to: <%= root %>/<%= path %>/<%= h.changeCase.pascal(name) %>/<%= h.changeCase.pascal(name) %>.stories.tsx
 ---
-<% const formattedName = h.inflection.transform(name, ['undasherize', 'classify']) -%>
+<% const formattedName = h.changeCase.pascal(name) -%>
 import { storiesOf } from '@storybook/react-native';
 import React from 'react';
 

--- a/_templates/react-native-typescript-screen/new/component.ejs
+++ b/_templates/react-native-typescript-screen/new/component.ejs
@@ -1,7 +1,7 @@
 ---
-to: <%= root %>/<%= path %>/<%= h.inflection.transform(name, ['undasherize', 'classify']) %>/<%= h.inflection.transform(name, ['undasherize', 'classify']) %>.tsx
+to: <%= root %>/<%= path %>/<%= h.changeCase.pascal(name) %>/<%= h.changeCase.pascal(name) %>.tsx
 ---
-<% const comp = h.inflection.transform(name, ['undasherize', 'classify']) -%>
+<% const comp = h.changeCase.pascal(name) -%>
 <% if(componentType === 'Class') { -%>
 import React, { Component } from 'react';
 import styled from '@emotion/native';

--- a/_templates/react-native-typescript-screen/new/export.ejs
+++ b/_templates/react-native-typescript-screen/new/export.ejs
@@ -1,4 +1,4 @@
 ---
-to: <%= root %>/<%= path %>/<%= h.inflection.transform(name, ['undasherize', 'classify']) %>/index.ts
+to: <%= root %>/<%= path %>/<%= h.changeCase.pascal(name) %>/index.ts
 ---
-export * from './<%= h.inflection.transform(name, ['undasherize', 'classify']) %>';
+export * from './<%= h.changeCase.pascal(name) %>';

--- a/src/__tests__/generate.test.ts
+++ b/src/__tests__/generate.test.ts
@@ -81,7 +81,7 @@ describe("The `generate` command", () => {
   });
   describe("react-native-typescript", () => {
     it("component template works and uses the default src/components path flag", async () => {
-      const componentName = "Reactnativetypescriptcomponent";
+      const componentName = "ReactNativeTtypescriptComponent";
       const componentFolderPath = `${tempRoot}/${componentName}`;
 
       execSync(

--- a/src/__tests__/generate.test.ts
+++ b/src/__tests__/generate.test.ts
@@ -79,61 +79,102 @@ describe("The `generate` command", () => {
     expect(componentIndexExists).toBe(true);
     expect(componentTsxExists).toBe(true);
   });
+  describe("react-native-typescript", () => {
+    it("component template works and uses the default src/components path flag", async () => {
+      const componentName = "Reactnativetypescriptcomponent";
+      const componentFolderPath = `${tempRoot}/${componentName}`;
 
-  it("works with the react-native-typescript-component template and uses the default src/components path flag", async () => {
-    const componentName = "Reactnativetypescriptcomponent";
-    const componentFolderPath = `${tempRoot}/${componentName}`;
-
-    execSync(
-      `./bin/run generate react-native-typescript-component -n ${componentName}`,
-      {
-        cwd: root
-      }
-    );
-
-    const newComponentFolderExists = await fse.pathExists(componentFolderPath);
-    const componentIndexExists = fse.existsSync(
-      `${componentFolderPath}/index.ts`
-    );
-    const componentTsxExists = fse.existsSync(
-      `${componentFolderPath}/${componentName}.tsx`
-    );
-
-    //Check if they have a storybook setup
-    const hasStoryBookDir = fse.existsSync(
-      `${tempRoot}/storybook/stories/index.ts`
-    );
-
-    // If they do,
-    // we assert that a .stories.tsx file was generated
-    if (hasStoryBookDir) {
-      const componentStoriesExists = fse.existsSync(
-        `${componentFolderPath}/${componentName}.stories.tsx`
+      execSync(
+        `./bin/run generate react-native-typescript-component -n ${componentName}`,
+        {
+          cwd: root
+        }
       );
-      expect(componentStoriesExists).toBe(true);
-    }
-    expect(newComponentFolderExists).toBe(true);
-    expect(componentIndexExists).toBe(true);
-    expect(componentTsxExists).toBe(true);
-  });
 
-  it.skip("works with the react-native-typescript-screen template and uses the default src/screens path", async () => {
-    // TODO - finish this test
-    // Because there is a prompt, we'll need to use a spawn from child_process.
-    // Will create followup ticket.
-    // const pathToScreens = path.join(`${root}/src`, "/screens");
-    // const componentName = "ReactNativeTypeScriptScreen";
-    // const componentFolderPath = `${pathToScreens}/${componentName}`;
-    // const newComponentFolderExists = await fse.pathExists(componentFolderPath);
-    // const componentIndexExists = fse.existsSync(
-    //   `${componentFolderPath}/index.ts`
-    // );
-    // const componentTsxExists = fse.existsSync(
-    //   `${componentFolderPath}/${componentName}.tsx`
-    // );
-    // expect(newComponentFolderExists).toBe(true);
-    // expect(componentIndexExists).toBe(true);
-    // expect(componentTsxExists).toBe(true);
+      const newComponentFolderExists = await fse.pathExists(
+        componentFolderPath
+      );
+      const componentIndexExists = fse.existsSync(
+        `${componentFolderPath}/index.ts`
+      );
+      const componentTsxExists = fse.existsSync(
+        `${componentFolderPath}/${componentName}.tsx`
+      );
+
+      //Check if they have a storybook setup
+      const hasStoryBookDir = fse.existsSync(
+        `${tempRoot}/storybook/stories/index.ts`
+      );
+
+      // If they do,
+      // we assert that a .stories.tsx file was generated
+      if (hasStoryBookDir) {
+        const componentStoriesExists = fse.existsSync(
+          `${componentFolderPath}/${componentName}.stories.tsx`
+        );
+        expect(componentStoriesExists).toBe(true);
+      }
+      expect(newComponentFolderExists).toBe(true);
+      expect(componentIndexExists).toBe(true);
+      expect(componentTsxExists).toBe(true);
+    });
+    it("component template properly cases and removes dashes", async () => {
+      const componentName = "myCool-other-component";
+      const expectedComponentName = "MyCoolOtherComponent";
+      const componentFolderPath = `${tempRoot}/${expectedComponentName}`;
+
+      execSync(
+        `./bin/run generate react-native-typescript-component -n ${componentName}`,
+        {
+          cwd: root
+        }
+      );
+
+      const newComponentFolderExists = await fse.pathExists(
+        componentFolderPath
+      );
+      const componentIndexExists = fse.existsSync(
+        `${componentFolderPath}/index.ts`
+      );
+      const componentTsxExists = fse.existsSync(
+        `${componentFolderPath}/${expectedComponentName}.tsx`
+      );
+
+      //Check if they have a storybook setup
+      const hasStoryBookDir = fse.existsSync(
+        `${tempRoot}/storybook/stories/index.ts`
+      );
+
+      // If they do,
+      // we assert that a .stories.tsx file was generated
+      if (hasStoryBookDir) {
+        const componentStoriesExists = fse.existsSync(
+          `${componentFolderPath}/${expectedComponentName}.stories.tsx`
+        );
+        expect(componentStoriesExists).toBe(true);
+      }
+      expect(newComponentFolderExists).toBe(true);
+      expect(componentIndexExists).toBe(true);
+      expect(componentTsxExists).toBe(true);
+    });
+    it.skip("works with the react-native-typescript-screen template and uses the default src/screens path", async () => {
+      // TODO - finish this test
+      // Because there is a prompt, we'll need to use a spawn from child_process.
+      // Will create followup ticket.
+      // const pathToScreens = path.join(`${root}/src`, "/screens");
+      // const componentName = "ReactNativeTypeScriptScreen";
+      // const componentFolderPath = `${pathToScreens}/${componentName}`;
+      // const newComponentFolderExists = await fse.pathExists(componentFolderPath);
+      // const componentIndexExists = fse.existsSync(
+      //   `${componentFolderPath}/index.ts`
+      // );
+      // const componentTsxExists = fse.existsSync(
+      //   `${componentFolderPath}/${componentName}.tsx`
+      // );
+      // expect(newComponentFolderExists).toBe(true);
+      // expect(componentIndexExists).toBe(true);
+      // expect(componentTsxExists).toBe(true);
+    });
   });
 
   it("works with the react-native-e2e template and uses the default e2e path", async () => {

--- a/src/__tests__/generate.test.ts
+++ b/src/__tests__/generate.test.ts
@@ -81,7 +81,7 @@ describe("The `generate` command", () => {
   });
   describe("react-native-typescript", () => {
     it("component template works and uses the default src/components path flag", async () => {
-      const componentName = "ReactNativeTtypescriptComponent";
+      const componentName = "ReactNativeTypeScriptComponent";
       const componentFolderPath = `${tempRoot}/${componentName}`;
 
       execSync(


### PR DESCRIPTION
This PR changes the component and screen generation templates for `react-native-typescript` so that it will use pascal casing and be consistent with the react templates.

## Changes

- `.ejs` files associated with Component & Screen in `react-native-typescript` templates
- added new test to validate the casing of components

## Screenshots
![2019-11-20 09 42 56](https://user-images.githubusercontent.com/7119624/69263448-32895c80-0b7a-11ea-9ab1-305d8ac82177.gif)

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [x] added a test

Fixes #43 
