### PR TITLE
chore(test): add TitleCase test for generate command

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -2,12 +2,13 @@
 name: Bug report 🐞
 about: Create a report to help us improve
 title: ""
-labels: ""
+labels: "bug"
 assignees: ""
 ---
 
 **Describe the bug**
-A clear and concise description of what the bug is.
+
+<!-- A clear and concise description of what the bug is. -->
 
 **To Reproduce**
 Steps to reproduce the behavior:
@@ -18,16 +19,13 @@ Steps to reproduce the behavior:
 4. See error
 
 **Expected behavior**
-A clear and concise description of what you expected to happen.
+
+<!-- A clear and concise description of what you expected to happen. -->
 
 **Screenshots**
-If applicable, add screenshots to help explain your problem.
 
-**Desktop (please complete the following information):**
-
-- OS: [e.g. iOS]
-- Browser [e.g. chrome, safari]
-- Version [e.g. 22]
+<!-- If applicable, add screenshots to help explain your problem. -->
 
 **Additional context**
-Add any other context about the problem here.
+
+<!-- Add any other context about the problem here. -->

--- a/src/__tests__/generate.test.ts
+++ b/src/__tests__/generate.test.ts
@@ -48,6 +48,7 @@ describe("The `generate` command", () => {
     });
 
     const newComponentFolderExists = await fse.pathExists(componentFolderPath);
+
     const componentIndexExists = fse.existsSync(
       `${componentFolderPath}/index.js`
     );
@@ -68,6 +69,7 @@ describe("The `generate` command", () => {
     );
 
     const newComponentFolderExists = await fse.pathExists(componentFolderPath);
+
     const componentIndexExists = fse.existsSync(
       `${componentFolderPath}/index.ts`
     );
@@ -75,10 +77,12 @@ describe("The `generate` command", () => {
     const componentTsxExists = fse.existsSync(
       `${componentFolderPath}/${componentName}.tsx`
     );
+
     expect(newComponentFolderExists).toBe(true);
     expect(componentIndexExists).toBe(true);
     expect(componentTsxExists).toBe(true);
   });
+
   describe("react-native-typescript", () => {
     it("component template works and uses the default src/components path flag", async () => {
       const componentName = "ReactNativeTypeScriptComponent";
@@ -94,9 +98,11 @@ describe("The `generate` command", () => {
       const newComponentFolderExists = await fse.pathExists(
         componentFolderPath
       );
+
       const componentIndexExists = fse.existsSync(
         `${componentFolderPath}/index.ts`
       );
+
       const componentTsxExists = fse.existsSync(
         `${componentFolderPath}/${componentName}.tsx`
       );
@@ -112,12 +118,15 @@ describe("The `generate` command", () => {
         const componentStoriesExists = fse.existsSync(
           `${componentFolderPath}/${componentName}.stories.tsx`
         );
+
         expect(componentStoriesExists).toBe(true);
       }
+
       expect(newComponentFolderExists).toBe(true);
       expect(componentIndexExists).toBe(true);
       expect(componentTsxExists).toBe(true);
     });
+
     it("component template properly cases and removes dashes", async () => {
       const componentName = "myCool-other-component";
       const expectedComponentName = "MyCoolOtherComponent";
@@ -133,9 +142,11 @@ describe("The `generate` command", () => {
       const newComponentFolderExists = await fse.pathExists(
         componentFolderPath
       );
+
       const componentIndexExists = fse.existsSync(
         `${componentFolderPath}/index.ts`
       );
+
       const componentTsxExists = fse.existsSync(
         `${componentFolderPath}/${expectedComponentName}.tsx`
       );
@@ -151,12 +162,59 @@ describe("The `generate` command", () => {
         const componentStoriesExists = fse.existsSync(
           `${componentFolderPath}/${expectedComponentName}.stories.tsx`
         );
+
         expect(componentStoriesExists).toBe(true);
       }
+
       expect(newComponentFolderExists).toBe(true);
       expect(componentIndexExists).toBe(true);
       expect(componentTsxExists).toBe(true);
     });
+
+    it("component template properly cases TitleCase", async () => {
+      const componentName = "ImageCard";
+      const expectedComponentName = "ImageCard";
+      const componentFolderPath = `${tempRoot}/${expectedComponentName}`;
+
+      execSync(
+        `./bin/run generate react-native-typescript-component -n ${componentName}`,
+        {
+          cwd: root
+        }
+      );
+
+      const newComponentFolderExists = await fse.pathExists(
+        componentFolderPath
+      );
+
+      const componentIndexExists = fse.existsSync(
+        `${componentFolderPath}/index.ts`
+      );
+
+      const componentTsxExists = fse.existsSync(
+        `${componentFolderPath}/${expectedComponentName}.tsx`
+      );
+
+      //Check if they have a storybook setup
+      const hasStoryBookDir = fse.existsSync(
+        `${tempRoot}/storybook/stories/index.ts`
+      );
+
+      // If they do,
+      // we assert that a .stories.tsx file was generated
+      if (hasStoryBookDir) {
+        const componentStoriesExists = fse.existsSync(
+          `${componentFolderPath}/${expectedComponentName}.stories.tsx`
+        );
+
+        expect(componentStoriesExists).toBe(true);
+      }
+
+      expect(newComponentFolderExists).toBe(true);
+      expect(componentIndexExists).toBe(true);
+      expect(componentTsxExists).toBe(true);
+    });
+
     it.skip("works with the react-native-typescript-screen template and uses the default src/screens path", async () => {
       // TODO - finish this test
       // Because there is a prompt, we'll need to use a spawn from child_process.
@@ -183,6 +241,7 @@ describe("The `generate` command", () => {
     execSync(`./bin/run generate react-native-e2e -n ${testName}`, {
       cwd: root
     });
+
     const pathToE2e = path.join(`${root}/${e2ePath}`);
     const testFilePath = `${pathToE2e}/${testName}.spec.js`;
 
@@ -202,6 +261,7 @@ describe("The `generate` command", () => {
         cwd: root
       }
     );
+
     const pathToUtils = path.join(`${root}/`, `${utilsPath}`);
     const utilTestFilePath = `${pathToUtils}/${testName}/test.ts`;
     const utilFilePath = `${pathToUtils}/${testName}/${testName}.ts`;
@@ -231,6 +291,7 @@ describe("The `generate` command", () => {
     );
 
     const newComponentFolderExists = await fse.pathExists(componentFolderPath);
+
     const componentIndexExists = fse.existsSync(
       `${componentFolderPath}/index.js`
     );
@@ -248,6 +309,7 @@ describe("The `generate` command", () => {
     });
 
     const newComponentFolderExists = await fse.pathExists(componentFolderPath);
+
     const componentIndexExists = fse.existsSync(
       `${componentFolderPath}/index.js`
     );
@@ -271,6 +333,7 @@ describe("The `generate` command", () => {
       `${root}/_templates/react-component`,
       `${root}/_templates/react-backup-component`
     );
+
     const pathToNewTemplate = `${root}/_templates/react-component/new`;
     const newComponentName = "Test";
     // Make a react-component template
@@ -282,6 +345,7 @@ describe("The `generate` command", () => {
     );
 
     const newTemplateFolderExists = await fse.pathExists(pathToNewTemplate);
+
     const newTemplateFileExists = fse.existsSync(
       `${pathToNewTemplate}/component.ejs.t`
     );


### PR DESCRIPTION
This PR adds an additional test for the `generate` command to check that we correctly create folders that are titled case i.e. `eb-scripts generate react-native-typescript-component -n ImageCard` -> `/components/ImageCard`

## Changes

- add new test

## Screenshots

![image](https://user-images.githubusercontent.com/3806031/71687223-9185e800-2d5a-11ea-9ccc-cd5b21a55b9d.png)


## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [x] added a test

Fixes #52 
